### PR TITLE
pyproject.toml: define "readme" file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.2.6"
 description = "Library to read .tsg file package"
 authors = ["Ben <ben@fractalgeoanalytics.com>"]
 license = "MIT"
+readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.8"


### PR DESCRIPTION
Define the readme file in `pyproject.toml` which will fix the "long_description" error when uploading to PyPI.