### PR TITLE
Lidar Reader Patch

### DIFF
--- a/src/pytsg/parse_tsg.py
+++ b/src/pytsg/parse_tsg.py
@@ -1,7 +1,6 @@
 """ The parse_tsg Module
 """
 
-import io
 import re
 import struct
 from dataclasses import dataclass

--- a/src/pytsg/parse_tsg.py
+++ b/src/pytsg/parse_tsg.py
@@ -630,7 +630,7 @@ def read_hires_dat(filename: Union[str, Path], per_spectra: bool =True) -> NDArr
         np.ndarray representing the profilometer data array.
     Examples:
     """
-    with open(hirespath, "rb") as f:
+    with open(filename, "rb") as f:
         _idchar = f.read(20)                            # "CoreLog high-res 1.0"
         _nsclr, _nl, nsps = np.fromfile(f, np.int32, 3) # 1, nbytes, samples per spectra
         minp, maxp = np.fromfile(f, np.float32, 2)      # minimum and maximum values

--- a/src/pytsg/parse_tsg.py
+++ b/src/pytsg/parse_tsg.py
@@ -631,14 +631,13 @@ def read_hires_dat(filename: Union[str, Path], per_spectra: bool =True) -> NDArr
     Examples:
     """
     with open(hirespath, "rb") as f:
-        idchar = f.read(20)  # CoreLog high-res 1.0
-        nsclr, nl, nsps = np.fromfile(f, np.int32, 3) # 1, nbytes, samples per spectra
-        minp, maxp = np.fromfile(f, np.float32, 2) # minimum and maximum values
-        _prof = f.read(12) # "Profilometer"
-        _ = np.fromfile(f, np.ubyte, 4) # four int8 zeros/null bytes
-        lidar = np.fromfile(f, dtype=np.float32)
-        # could do additional validation here
-        lidar[lidar < minp] = np.nan
+        _idchar = f.read(20)                            # "CoreLog high-res 1.0"
+        _nsclr, _nl, nsps = np.fromfile(f, np.int32, 3) # 1, nbytes, samples per spectra
+        minp, maxp = np.fromfile(f, np.float32, 2)      # minimum and maximum values
+        _prof = f.read(12)                              # "Profilometer"
+        _ = np.fromfile(f, np.ubyte, 4)                 # four int8 zeros/null bytes
+        lidar = np.fromfile(f, dtype=np.float32)        # nl bytes of profilometer data
+        lidar[lidar < minp] = np.nan                    # could do additional validation here
 
     if per_spectra:
         with warnings.catch_warnings():

--- a/src/pytsg/parse_tsg.py
+++ b/src/pytsg/parse_tsg.py
@@ -7,6 +7,7 @@ import struct
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, NamedTuple, Tuple, Union
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -619,19 +620,31 @@ def _calculate_wavelengths(
     )
 
 
-def read_hires_dat(filename: Union[str, Path]) -> NDArray:
+def read_hires_dat(filename: Union[str, Path], per_spectra: bool =True) -> NDArray:
     """Read the *hires.dat* file which contains the lidar scan
     of the material
 
     Args:
         filename: location of the .dat file
+        per_spectra : whether to get one sample per spectra, or all samples.
     Returns:
-        np.ndarray representing the
+        np.ndarray representing the profilometer data array.
     Examples:
     """
-    # the hires .dat file is f32 and the actual data starts at pos 640
-    # the rest is probably information pertaining to the instrument itself
-    lidar = np.fromfile(filename, dtype=np.float32, offset=640)
+    with open(hirespath, "rb") as f:
+        idchar = f.read(20)  # CoreLog high-res 1.0
+        nsclr, nl, nsps = np.fromfile(f, np.int32, 3) # 1, nbytes, samples per spectra
+        minp, maxp = np.fromfile(f, np.float32, 2) # minimum and maximum values
+        _prof = f.read(12) # "Profilometer"
+        _ = np.fromfile(f, np.ubyte, 4) # four int8 zeros/null bytes
+        lidar = np.fromfile(f, dtype=np.float32)
+        # could do additional validation here
+        lidar[lidar < minp] = np.nan
+
+    if per_spectra:
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message="Mean of empty slice")
+            lidar = np.nanmean(lidar.reshape(-1, nsps), axis=1)
     return lidar
 
 


### PR DESCRIPTION
It seems that the current lidar data file reader (`pytsg.parse_tsg.read_hires_dat()`) doesn't quite match the file structure of the `*_hires.dat` files, and the amendments in this PR should provide a general solution which fits at least the current generation of instruments. 

Additionally:
* a `per_spectra` keyword argument is added to this function, allowing (by default) the return of one profilometer sample per spectra rather than multiple, making it easier to view these side-by-side. The same or similar keyword argument could optionally be added as to `pytsg.parse_tsg.read_package()` and then passed into `read_hires_dat()` if you see particular value in the higher resolution data.
* an unused `io` import is removed.