### PR TITLE
Minor changes to address numpy deprecation and runtime warnings

### DIFF
--- a/src/pytsg/feature.py
+++ b/src/pytsg/feature.py
@@ -99,7 +99,7 @@ def sqm(
     output[:, 1] = vertex[:, 0]
     # calculate the width of the polynomial at 0
     for i in range(rows):
-        output[i, 2] = np.diff(poly.polyroots(coefs[:, i].ravel()))
+        output[i, 2] = np.diff(poly.polyroots(coefs[:, i].ravel()))[0]
     # concatenate the parameters into output array
     output_coefs = coefs.T
     return output, output_coefs

--- a/src/pytsg/parse_tsg.py
+++ b/src/pytsg/parse_tsg.py
@@ -1097,7 +1097,10 @@ def _parse_tsg(
 
 
 def _parse_scalars(
-    scalars: NDArray, classes: "list[ClassHeaders]", bandheaders: "list[BandHeaders]"
+    scalars: NDArray,
+    classes: "list[ClassHeaders]",
+    bandheaders: "list[BandHeaders]",
+    nodata: int = -1,
 ) -> pd.DataFrame:
     """
     function to map the scalars to a pandas data frame with names and
@@ -1109,7 +1112,13 @@ def _parse_scalars(
         # handle flag 13 that has a path to plsscalars
         if i.flag == 2:
             if i.class_number > 0:
-                bv = band_value.astype(int)
+                # replace missing values with `nodata (defaulting to -1)
+                # Note: the integer shouldn't exist in the `classes` keys
+                bv = np.where(
+                    np.isclose(band_value, np.finfo("float32").min),
+                    -1,
+                    band_value,
+                ).astype(int)
                 tn = classes[i.class_number].map_ints(bv)
                 tmp_series.append(pd.DataFrame(tn, columns=[i.name]))
             else:


### PR DESCRIPTION
This PR addresses two instances of unnecessary warnings produced while using some newer versions of `numpy` (tested with `numpy` v1.26 and Python 3.11):
* While casting float32 minimum values (missing data) to integers during categorical scalar mapping
* In the extraction of quadratic features

